### PR TITLE
fix: Add missing import for NotificationHandlerService

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'screens/configure_server_screen.dart';
 import 'services/auth_service.dart';
 import 'background/zabbix_foreground_task.dart';
 import 'services/notification_service.dart';
+import 'services/notification_handler_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
This commit fixes a build error caused by a missing import for the `NotificationHandlerService` in `main.dart`. The import has been added, and the build should now succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of notifications received when launching the app from a closed state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->