### PR TITLE
Show friendly message for Zabbix API permission errors

### DIFF
--- a/lib/api/zabbix_api.dart
+++ b/lib/api/zabbix_api.dart
@@ -252,6 +252,34 @@ class ZabbixApiException implements Exception {
   ZabbixApiException(this.message, this.details);
   final String message;
   final Map<String, dynamic> details;
+
+  /// The Zabbix JSON-RPC error code, if this wraps an `{"error": {...}}` response.
+  int? get code {
+    final raw = details['code'];
+    if (raw is int) return raw;
+    return int.tryParse(raw?.toString() ?? '');
+  }
+
+  /// True when Zabbix rejected the call because the authenticated user's role
+  /// isn't allowed to call the API at all (JSON-RPC code -32500 with a
+  /// "No permissions to call ..." data message). This is a role-level
+  /// "API access" toggle in Zabbix, not a host-group permission gap, so it
+  /// affects every API method for that account, not just the one that failed.
+  bool get isPermissionError =>
+      code == -32500 &&
+      (details['data']?.toString().toLowerCase().contains('no permissions') ?? false);
+
+  /// A message safe to show directly to end users, instead of the raw
+  /// JSON-RPC error payload.
+  String get friendlyMessage {
+    if (isPermissionError) {
+      return 'Your Zabbix account is not allowed to use the API.\n\n'
+          'Ask your Zabbix administrator to enable "Enabled" under API access '
+          'for your user role (Administration → Users → Roles), then try again.';
+    }
+    return message;
+  }
+
   @override
   String toString() => 'ZabbixApiException: $message ${jsonEncode(details)}';
 }

--- a/lib/screens/problems_screen.dart
+++ b/lib/screens/problems_screen.dart
@@ -11,6 +11,7 @@ import 'package:file_picker/file_picker.dart';
 import '../services/sound_service.dart';
 import '../services/notification_handler_service.dart';
 import '../services/zabbix_polling_service.dart';
+import '../api/zabbix_api.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 // Recovery sounds are low-urgency: unlike problem alerts, they must not
@@ -721,7 +722,33 @@ class _ProblemsScreenState extends State<ProblemsScreen> {
             // Print errors to stdout for easier debugging on Linux
             // ignore: avoid_print
             debugPrint('ProblemsScreen error: ${snapshot.error}');
-            return Center(child: Text('Error: ${snapshot.error}'));
+            final error = snapshot.error;
+            final message = error is ZabbixApiException ? error.friendlyMessage : 'Error: $error';
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      error is ZabbixApiException && error.isPermissionError
+                          ? Icons.lock_outline
+                          : Icons.error_outline,
+                      size: 48,
+                      color: Colors.red,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(message, textAlign: TextAlign.center),
+                    const SizedBox(height: 16),
+                    ElevatedButton.icon(
+                      onPressed: _refreshData,
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('Retry'),
+                    ),
+                  ],
+                ),
+              ),
+            );
           }
           final items = snapshot.data ?? const [];
           


### PR DESCRIPTION
## Summary
- Fixes the raw `ZabbixApiException` dump reported in #10 for the case where the Zabbix user's role has API access disabled entirely (JSON-RPC code `-32500`, "No permissions to call ...").
- `ZabbixApiException` (`lib/api/zabbix_api.dart`) now exposes `code`, `isPermissionError`, and `friendlyMessage` getters.
- `ProblemsScreen`'s error branch (`lib/screens/problems_screen.dart`) shows an icon + actionable message + **Retry** button (reusing the existing `_refreshData()`), instead of `Text('Error: ${snapshot.error}')`.

## Root cause
As detailed in the investigation on #10: this error isn't a host-group permission gap — it's the Zabbix role's "API access" toggle being off (`api.access: 0`), which makes *every* API call fail identically for that account (`host.get`, `problem.get`, etc.). The app had no handling for this class of error at all.

## Test plan
- [ ] `flutter analyze` / `flutter test` (not run here — no Flutter SDK available in this environment; please run in CI)
- [ ] Manually reproduce with a Zabbix user whose role has API access disabled and confirm the friendly message + Retry button render instead of the raw exception
- [ ] Confirm Retry re-fetches once API access is re-enabled server-side

Closes/relates to #10 (root-cause analysis and screenshots posted there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages on the Problems screen.
  * Added a clear permission-related message when access is denied.
  * Added a contextual error icon for permission issues.
  * Added a **Retry** button to recover from loading errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->